### PR TITLE
Cover case with null transitions as finalize state

### DIFF
--- a/src/Traits/EloquentHasStateMachines.php
+++ b/src/Traits/EloquentHasStateMachines.php
@@ -60,6 +60,8 @@ trait EloquentHasStateMachines
                 $transitions = [];
             }
 
+            $transitions ??= [];
+
             if (in_array(Nullable::class, class_implements($state))) {
                 $transitions = [
                     ...$transitions,

--- a/tests/TestModels/OrderDeliveryStatus.php
+++ b/tests/TestModels/OrderDeliveryStatus.php
@@ -11,7 +11,7 @@ enum OrderDeliveryStatus implements DefineStates, Nullable
     case Pending;
     case Finished;
 
-    public function transitions(): array
+    public function transitions(): ?array
     {
         return match ($this) {
             self::Default => [
@@ -20,6 +20,7 @@ enum OrderDeliveryStatus implements DefineStates, Nullable
             self::Pending => [
                 'finish' => self::Finished,
             ],
+            default => null,
         };
     }
 


### PR DESCRIPTION
There's some cases where we want to declare null as finalize state for more clarification. But null will break the loop function so we need to add fallback for null value