### PR TITLE
register state machine to service container

### DIFF
--- a/src/Contracts/StateMachine.php
+++ b/src/Contracts/StateMachine.php
@@ -6,6 +6,8 @@ use UnitEnum;
 
 interface StateMachine
 {
+    public function __construct(HasStateMachine $hasStateMachine, string $field);
+
     /**
      * Return current state
      *

--- a/src/Providers/EnumataServiceProvider.php
+++ b/src/Providers/EnumataServiceProvider.php
@@ -4,9 +4,16 @@ namespace Norotaro\Enumata\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Norotaro\Enumata\Console\Commands\ModelStateMakeCommand;
+use Norotaro\Enumata\Contracts\StateMachine;
+use Norotaro\Enumata\EnumStateMachine;
 
 final class EnumataServiceProvider extends ServiceProvider
 {
+    public function register()
+    {
+        $this->app->bind(StateMachine::class, EnumStateMachine::class);
+    }
+
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
Right now, if we want to modify something in `EnumStateMachine`, we have to extend it, and fix in the trait `EloquentHasStateMachine` as well since the trait use the `EnumStateMachine` directly.

To reduce the work and separate the concenrs, we should bind `StateMachine` contract to service container, so we can easily swap it later for certain use case. 